### PR TITLE
Save actual time window length in index

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.krasserm"
 
 name := "akka-persistence-cassandra"
 
-version := "0.5-jypma-201511161434"
+version := "0.5-jypma-201511241013"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
@@ -30,6 +30,7 @@ parallelExecution in Test := false
 libraryDependencies ++= Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"             % "2.1.5",
   "com.typesafe.akka"      %% "akka-persistence"                  % "2.4.0",
+  "com.typesafe.akka"      %% "akka-cluster-tools"                % "2.4.0",
   "com.typesafe.akka"      %% "akka-persistence-tck"              % "2.4.0"      % "test",
   "org.scalatest"          %% "scalatest"                         % "2.1.4"      % "test",
   "org.cassandraunit"       % "cassandra-unit"                    % "2.1.9.2"    % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.github.krasserm"
 
 name := "akka-persistence-cassandra"
 
-version := "0.5-jypma-201511031129"
+version := "0.5-jypma-201511161434"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -70,7 +70,7 @@ cassandra-journal {
   time-index-table = "messagesTimeIndex"
 
   # fixed length of time window index slices
-  time-window-length = 60000
+  time-window-length = 60 seconds
 }
 
 cassandra-snapshot-store {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -18,11 +18,16 @@ import com.datastax.driver.core.utils.Bytes
 import java.util.Calendar
 import java.util.Date
 import akka.persistence.cassandra.query.Timestamped
+import akka.cluster.pubsub.DistributedPubSub
+import akka.cluster.pubsub.DistributedPubSubMediator.Publish
 
 class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with CassandraStatements {
 
   val config = new CassandraJournalConfig(context.system.settings.config.getConfig("cassandra-journal"))
   val serialization = SerializationExtension(context.system)
+  
+  // if no clustering available, then just don't publish messages.
+  val pubsub = Try(DistributedPubSub(context.system).mediator).toOption 
 
   import config._
 
@@ -71,6 +76,16 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
 
     val byPersistenceId = serialized.collect({ case Success(caw) => caw }).groupBy(_.persistenceId).values
     val boundStatements = byPersistenceId.map(statementGroup)
+    for (p <- pubsub) {
+      if (boundStatements.flatten.exists(_.preparedStatement eq preparedWriteTimeIndex)) {
+        p ! Publish("persistenceIndex", "added")
+      }
+      for (writes <- byPersistenceId) {
+        val pId = writes.head.persistenceId
+        val seqNr = writes.last.payload.last.sequenceNr
+        p ! Publish(s"persistenceId:$pId", s"added:$seqNr")
+      }
+    }
 
     val batchStatements = boundStatements.map({ unit =>
         executeBatch(batch => unit.foreach(batch.add))

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -108,7 +108,8 @@ class CassandraJournal extends AsyncWriteJournal with CassandraRecovery with Cas
       val cal = Calendar.getInstance
       cal.setTimeInMillis(placement.windowStart)
       val year_month_day = cal.get(Calendar.YEAR) * 10000 + cal.get(Calendar.MONTH) * 100 + cal.get(Calendar.DAY_OF_MONTH)
-      preparedWriteTimeIndex.bind(year_month_day: JInt, new Date(placement.windowStart), firstSeq: JLong, persistenceId, minPnr: JLong)      
+      preparedWriteTimeIndex.bind(year_month_day: JInt, new Date(placement.windowStart), config.timeWindowLength.toMillis(): JLong, 
+                                  firstSeq: JLong, persistenceId, minPnr: JLong)      
     }
     
     val writes = eventWrites ++ indexWrites

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -2,8 +2,8 @@ package akka.persistence.cassandra.journal
 
 import com.typesafe.config.Config
 import scala.collection.JavaConverters._
-
 import akka.persistence.cassandra.CassandraPluginConfig
+import java.time.Duration
 
 class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(config) {
   val replayDispatcherId: String = config.getString("replay-dispatcher")
@@ -13,7 +13,7 @@ class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(confi
   val maxMessageBatchSize = config.getInt("max-message-batch-size")
   val deleteRetries: Int = config.getInt("delete-retries")
   val timeIndexTable: String = config.getString("time-index-table")
-  val timeWindowLength: Long = config.getLong("time-window-length")
+  val timeWindowLength: Duration = config.getDuration("time-window-length")
 }
 
 object CassandraJournalConfig {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -28,6 +28,7 @@ trait CassandraStatements {
       CREATE TABLE IF NOT EXISTS ${timeIndexTableName} (
         year_month_day int,
         window_start timestamp,
+        window_length bigint,
         persistence_id text,
         first_sequence_nr_in_window bigint,
         partition_nr bigint,
@@ -49,8 +50,8 @@ trait CassandraStatements {
     """
 
   def writeMessageTimeIndex = s"""
-      INSERT INTO ${timeIndexTableName} (year_month_day, window_start, first_sequence_nr_in_window, persistence_id, partition_nr)
-      VALUES (?, ?, ?, ?, ?)
+      INSERT INTO ${timeIndexTableName} (year_month_day, window_start, window_length, first_sequence_nr_in_window, persistence_id, partition_nr)
+      VALUES (?, ?, ?, ?, ?, ?)
     """
 
   def deleteMessage = s"""

--- a/src/test/scala/akka/persistence/cassandra/journal/TimeWindowSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/TimeWindowSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.Matchers
 import akka.persistence.cassandra.query.Timestamped
 import java.time.Instant
 import akka.persistence.cassandra.journal.TimeWindow.Placement
+import java.time.Duration
 
 class TimeWindowSpec extends WordSpec with Matchers {
 
@@ -14,14 +15,14 @@ class TimeWindowSpec extends WordSpec with Matchers {
 
   "A TimeWindow instance" must {
     "place events with similar timestamps into the same time window" in {
-      val window = new TimeWindow(1000)
+      val window = new TimeWindow(Duration.ofSeconds(1))
 
       window.place("doc", Event(Instant.ofEpochMilli(1000))) should be (Placement(1000, true))
       window.place("doc", Event(Instant.ofEpochMilli(1001))) should be (Placement(1000, false))
     }
 
     "forget about old instances after 4 * time window length has passed" in {
-      val window = new TimeWindow(1000)
+      val window = new TimeWindow(Duration.ofSeconds(1))
 
       window.place("doc", Event(Instant.ofEpochMilli(1000))) should be (Placement(1000, true))
       window.place("doc", Event(Instant.ofEpochMilli(5000))) should be (Placement(5000, true))


### PR DESCRIPTION
This allows the query plugin to accurately read only the events that lie
exactly in the time window, before continuing on to further events.

@domask please have a look
